### PR TITLE
cicd: removed entrypoint from dockerimage

### DIFF
--- a/Dockerfile.custom
+++ b/Dockerfile.custom
@@ -21,9 +21,4 @@ RUN apt-get update -y
 RUN apt-get upgrade -y
 RUN apt-get install -y wget
 RUN apt-get install -y postgresql-client
-COPY entrypoint.sh .
-# Make the script executable
-RUN chmod +x entrypoint.sh
-COPY pgstac.0.7.9.sql /tmp/pgstac.sql
-ENTRYPOINT ["./entrypoint.sh"]
 CMD ["uvicorn", "stac_fastapi.pgstac.app:app", "--host", "0.0.0.0", "--port", "8082"]


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `make test`)
- [ ] Documentation has been updated to reflect changes, if applicable, and docs build successfully (run `make docs`)
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/stac-fastapi/blob/main/CHANGES.md).
